### PR TITLE
Add highlight to available skills / modifiers / passives / lines

### DIFF
--- a/components/skill/SkillItem.vue
+++ b/components/skill/SkillItem.vue
@@ -161,7 +161,7 @@ const isActive = computed<boolean>(() => props.rank > 0)
 
 const outerSquareStyles = computed(() => ({
   'fill-red-800': isActive.value,
-  'fill-[#e5dcc8]/60': props.highlight && !isActive.value,
+  'fill-[#ccb692]': props.highlight && !isActive.value,
   'fill-[#191f20]': !isActive.value
 }))
 

--- a/components/skill/SkillItem.vue
+++ b/components/skill/SkillItem.vue
@@ -161,7 +161,7 @@ const isActive = computed<boolean>(() => props.rank > 0)
 
 const outerSquareStyles = computed(() => ({
   'fill-red-800': isActive.value,
-  'fill-[#ccb692]': props.highlight && !isActive.value,
+  'fill-[#e3d9c0]': props.highlight && !isActive.value,
   'fill-[#191f20]': !isActive.value
 }))
 

--- a/components/skill/SkillItem.vue
+++ b/components/skill/SkillItem.vue
@@ -35,7 +35,7 @@
         <!-- Outer Square -->
         <rect
           class="skill-item__outer-square transition-colors"
-          :class="outerSquareBg"
+          :class="outerSquareStyles"
           width="45"
           height="45"
           fill="#191f20"
@@ -142,7 +142,8 @@ defineEmits<{
 
 interface Props {
   active?: boolean
-  tooltip?: boolean,
+  highlight?: boolean
+  tooltip?: boolean
   icon?: string
   rank?: number
   rankMax?: number
@@ -158,9 +159,15 @@ const props = withDefaults(defineProps<Props>(), {
 
 const isActive = computed<boolean>(() => props.rank > 0)
 
-const outerSquareBg = computed<string>(() => isActive.value ? useActiveFill() : '!fill-[#191f20]')
+// const outerSquareBg = computed<string>(() => isActive.value ? useActiveFill() : '!fill-[#191f20]')
+const outerSquareStyles = computed(() => ({
+  'fill-red-800': isActive.value,
+  'fill-[#e5dcc8]/60': props.highlight && !isActive.value,
+  'fill-[#191f20]': !isActive.value
+}))
+// isActive.value ? useActiveFill() : '!fill-[#191f20]')
 
-const iconOpacity = computed<string>(() => isActive.value || props.tooltip ? '1' : '0.6')
+const iconOpacity = computed<string>(() => isActive.value || props.tooltip || props.highlight ? '1' : '0.6')
 
 const rankClass = computed<string>(() => props.rank <= 0 ? 'opacity-0' : 'opacity-100')
 </script>

--- a/components/skill/SkillItem.vue
+++ b/components/skill/SkillItem.vue
@@ -159,13 +159,11 @@ const props = withDefaults(defineProps<Props>(), {
 
 const isActive = computed<boolean>(() => props.rank > 0)
 
-// const outerSquareBg = computed<string>(() => isActive.value ? useActiveFill() : '!fill-[#191f20]')
 const outerSquareStyles = computed(() => ({
   'fill-red-800': isActive.value,
   'fill-[#e5dcc8]/60': props.highlight && !isActive.value,
   'fill-[#191f20]': !isActive.value
 }))
-// isActive.value ? useActiveFill() : '!fill-[#191f20]')
 
 const iconOpacity = computed<string>(() => isActive.value || props.tooltip || props.highlight ? '1' : '0.6')
 

--- a/components/skill/SkillItemModifier.vue
+++ b/components/skill/SkillItemModifier.vue
@@ -167,7 +167,7 @@ const props = withDefaults(defineProps<Props>(), {
 const outerSquareStyles = computed(() => ({
   'fill-[#191f20]': !props.active,
   'fill-red-800': props.active,
-  'fill-[#e5dcc8]/60': props.highlight && !props.active
+  'fill-[#ccb692]': props.highlight && !props.active
 }))
 
 const iconOpacity = computed<string>(() => props.active || props.tooltip || props.highlight ? '1' : '0.6')

--- a/components/skill/SkillItemModifier.vue
+++ b/components/skill/SkillItemModifier.vue
@@ -167,7 +167,7 @@ const props = withDefaults(defineProps<Props>(), {
 const outerSquareStyles = computed(() => ({
   'fill-[#191f20]': !props.active,
   'fill-red-800': props.active,
-  'fill-[#ccb692]': props.highlight && !props.active
+  'fill-[#e3d9c0]': props.highlight && !props.active
 }))
 
 const iconOpacity = computed<string>(() => props.active || props.tooltip || props.highlight ? '1' : '0.6')

--- a/components/skill/SkillItemModifier.vue
+++ b/components/skill/SkillItemModifier.vue
@@ -34,7 +34,6 @@
       >
         <rect
           class="skill-item-modifier__outer-border opacity-0 transition-colors"
-          :class="outerSquareBg"
           width="24"
           height="24"
           transform="rotate(45, 12, 12)"
@@ -47,7 +46,7 @@
         <!-- Outer Square -->
         <rect
           class="skill-item-modifier__outer-square transition-colors"
-          :class="outerSquareBg"
+          :class="outerSquareStyles"
           width="24"
           height="24"
           fill="#191f20"
@@ -62,7 +61,7 @@
         <rect
           width="18"
           height="18"
-          fill="transparent"
+          fill="black"
           transform="rotate(45, 9, 9)"
           x="11"
           y="11"
@@ -154,7 +153,8 @@ defineEmits<{
 
 interface Props {
   active?: boolean
-  tooltip?: boolean,
+  highlight?: boolean
+  tooltip?: boolean
   icon?: string
 }
 
@@ -164,9 +164,13 @@ const props = withDefaults(defineProps<Props>(), {
   icon: ''
 })
 
-const outerSquareBg = computed<string>(() => props.active ? useActiveFill() : '!fill-[#191f20]')
+const outerSquareStyles = computed(() => ({
+  'fill-[#191f20]': !props.active,
+  'fill-red-800': props.active,
+  'fill-[#e5dcc8]/60': props.highlight && !props.active
+}))
 
-const iconOpacity = computed<string>(() => props.active || props.tooltip ? '1' : '0.6')
+const iconOpacity = computed<string>(() => props.active || props.tooltip || props.highlight ? '1' : '0.6')
 </script>
 
 <style scoped lang="postcss">

--- a/components/skill/SkillLine.vue
+++ b/components/skill/SkillLine.vue
@@ -33,7 +33,7 @@ const props = withDefaults(defineProps<Props>(), {
 
 const lineStyles = computed(() => ({
   'stroke-[#191f20]': !props.active && !props.highlight,
-  'stroke-[#e5dcc8]/40': props.highlight && !props.active,
+  'stroke-[#ccb692]/50': props.highlight && !props.active,
   'stroke-red-800': props.active
 }))
 

--- a/components/skill/SkillLine.vue
+++ b/components/skill/SkillLine.vue
@@ -33,7 +33,7 @@ const props = withDefaults(defineProps<Props>(), {
 
 const lineStyles = computed(() => ({
   'stroke-[#191f20]': !props.active && !props.highlight,
-  'stroke-[#ccb692]/50': props.highlight && !props.active,
+  'stroke-[#e3d9c0]/50': props.highlight && !props.active,
   'stroke-red-800': props.active
 }))
 

--- a/components/skill/SkillLine.vue
+++ b/components/skill/SkillLine.vue
@@ -35,7 +35,7 @@ const props = withDefaults(defineProps<Props>(), {
 
 const lineStyles = computed(() => ({
   'stroke-[#191f20]': !props.active && !props.highlight,
-  'stroke-[#e5dcc8]/50': props.highlight && !props.active,
+  'stroke-[#e5dcc8]/40': props.highlight && !props.active,
   'stroke-red-800': props.active
 }))
 

--- a/components/skill/SkillLine.vue
+++ b/components/skill/SkillLine.vue
@@ -31,8 +31,6 @@ const props = withDefaults(defineProps<Props>(), {
   active: false
 })
 
-// const lineStroke = computed<string>(() => props.active ? 'stroke-red-800' : 'stroke-[#191f20]')
-
 const lineStyles = computed(() => ({
   'stroke-[#191f20]': !props.active && !props.highlight,
   'stroke-[#e5dcc8]/40': props.highlight && !props.active,

--- a/components/skill/SkillLine.vue
+++ b/components/skill/SkillLine.vue
@@ -13,7 +13,7 @@
     :y1="y1"
     :x2="x2"
     :y2="y2"
-    :class="lineStroke"
+    :class="lineStyles"
     stroke-width="5"
   />
 </template>
@@ -21,8 +21,9 @@
 <script setup lang="ts">
 interface Props {
   active?: boolean
-  el1: HTMLElement,
-  el2: HTMLElement,
+  highlight?: boolean
+  el1: HTMLElement
+  el2: HTMLElement
   parent: HTMLElement
 }
 
@@ -30,6 +31,13 @@ const props = withDefaults(defineProps<Props>(), {
   active: false
 })
 
-const lineStroke = computed<string>(() => props.active ? 'stroke-red-800' : 'stroke-[#191f20]')
+// const lineStroke = computed<string>(() => props.active ? 'stroke-red-800' : 'stroke-[#191f20]')
+
+const lineStyles = computed(() => ({
+  'stroke-[#191f20]': !props.active && !props.highlight,
+  'stroke-[#e5dcc8]/50': props.highlight && !props.active,
+  'stroke-red-800': props.active
+}))
+
 const { x1, y1, x2, y2 } = computed(() => getLineCoordinates(props.parent, props.el1, props.el2)).value
 </script>

--- a/components/skill/SkillTooltip.vue
+++ b/components/skill/SkillTooltip.vue
@@ -130,68 +130,43 @@
 </template>
 
 <script setup lang="ts">
-const props = defineProps({
-  active: {
-    type: Boolean,
-    default: false
-  },
-  name: {
-    type: String,
-    default: ''
-  },
-  description: {
-    type: String,
-    default: ''
-  },
-  descriptionValues: {
-    type: Object,
-    default () {
-      return {}
-    }
-  },
-  icon: {
-    type: String,
-    default: ''
-  },
-  rank: {
-    type: Number,
-    default: 0
-  },
-  rankMax: {
-    type: Number,
-    default: 0
-  },
-  category: {
-    type: String,
-    default: ''
-  },
-  type: {
-    type: String,
-    default: ''
-  },
-  school: {
-    type: String,
-    default: ''
-  },
-  modifiers: {
-    type: Array,
-    default: () => []
-  },
-  damageType: {
-    type: String,
-    default: ''
-  },
-  translateX: {
-    type: Number,
-    default: 0
-  },
-  translateY: {
-    type: Number,
-    default: 0
-  }
+import { ISkillModifier, ISkillDescriptionValues } from '@/utils/skills'
+
+interface Props {
+  active?: boolean
+  name?: string
+  description: string
+  descriptionValues: ISkillDescriptionValues
+  rank: number
+  rankMax: number
+  icon?: string
+  category?: string
+  type?: string
+  school?: string
+  modifier?: ISkillModifier | undefined
+  damageType?: string
+  translateX?: number
+  translateY?: number
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  active: false,
+  name: '',
+  description: '',
+  descriptionValues: () => ({} as ISkillDescriptionValues),
+  rank: 0,
+  rankMax: 0,
+  icon: '/svg/skill/tier/skill-tier-icon-basic.svg',
+  category: '',
+  type: '',
+  school: '',
+  modifier: undefined,
+  damageType: '',
+  translateX: 0,
+  translateY: 0
 })
 
-const schools = computed(() => props.school.split(','))
+const schools = computed(() => props.school?.split(','))
 
 const notLearnedVisible = computed(() => {
   return props.rank <= 0 && !props.active
@@ -226,13 +201,11 @@ const nextRankList = computed(() => {
 const tooltipModifiers = computed(() => {
   const modifiers: any[] = []
 
-  props.modifiers?.forEach((modifier: any) => {
-    if (modifier.active) modifiers.push(modifier)
+  if (props.modifier?.active) modifiers.push(props.modifier)
 
-    modifier?.choiceModifiers
-      ?.filter((choiceModifier: any) => choiceModifier.active)
-      ?.forEach((choiceModifier: any) => modifiers.push(choiceModifier))
-  })
+  props.modifier?.choiceModifiers
+    ?.filter((choiceModifier: any) => choiceModifier.active)
+    ?.forEach((choiceModifier: any) => modifiers.push(choiceModifier))
 
   return modifiers?.map((modifier) => {
     return modifier?.description

--- a/components/skill/SkillTooltip.vue
+++ b/components/skill/SkillTooltip.vue
@@ -81,9 +81,9 @@
         >
           <!-- eslint-disable vue/no-v-html -->
           <li
-            v-for="(modifier, index) in tooltipModifiers"
+            v-for="(modifierItem, index) in tooltipModifiers"
             :key="index"
-            v-html="modifier"
+            v-html="modifierItem"
           />
           <!-- eslint-enable vue/no-v-html -->
         </ul>

--- a/components/skill/SkillTooltip.vue
+++ b/components/skill/SkillTooltip.vue
@@ -135,10 +135,10 @@ import { ISkillModifier, ISkillDescriptionValues } from '@/utils/skills'
 interface Props {
   active?: boolean
   name?: string
-  description: string
-  descriptionValues: ISkillDescriptionValues
-  rank: number
-  rankMax: number
+  description?: string
+  descriptionValues?: ISkillDescriptionValues
+  rank?: number
+  rankMax?: number
   icon?: string
   category?: string
   type?: string

--- a/components/skill/passive/SkillPassive.vue
+++ b/components/skill/passive/SkillPassive.vue
@@ -25,7 +25,7 @@
         <!-- Outer Square -->
         <rect
           class="skill-item-passive__outer-square transition-colors"
-          :class="outerSquareBg"
+          :class="outerSquareStyles"
           width="30"
           height="30"
           fill="#191f20"
@@ -71,7 +71,8 @@ defineEmits<{
 
 interface Props {
   active?: boolean
-  tooltip?: boolean,
+  highlight?: boolean
+  tooltip?: boolean
   icon?: string
   rank?: number
   rankMax?: number
@@ -79,6 +80,7 @@ interface Props {
 
 const props = withDefaults(defineProps<Props>(), {
   active: false,
+  highlight: false,
   tooltip: false,
   icon: '',
   rank: 0,
@@ -87,7 +89,11 @@ const props = withDefaults(defineProps<Props>(), {
 
 const isActive = computed<boolean>(() => props.rank > 0)
 
-const outerSquareBg = computed<string>(() => isActive.value ? useActiveFill() : '!fill-[#191f20]')
+const outerSquareStyles = computed(() => ({
+  'fill-red-800': isActive.value,
+  'fill-[#ccb692]': props.highlight && !isActive.value,
+  'fill-[#191f20]': !isActive.value
+}))
 
 const iconOpacity = computed<string>(() => isActive.value || props.tooltip ? '1' : '0.6')
 

--- a/components/skill/passive/SkillPassive.vue
+++ b/components/skill/passive/SkillPassive.vue
@@ -91,7 +91,7 @@ const isActive = computed<boolean>(() => props.rank > 0)
 
 const outerSquareStyles = computed(() => ({
   'fill-red-800': isActive.value,
-  'fill-[#ccb692]': props.highlight && !isActive.value,
+  'fill-[#e3d9c0]': props.highlight && !isActive.value,
   'fill-[#191f20]': !isActive.value
 }))
 

--- a/components/skill/passive/SkillPassiveLine.vue
+++ b/components/skill/passive/SkillPassiveLine.vue
@@ -55,7 +55,7 @@ const dpath = computed(() => {
 // const lineStroke = computed<string>(() => props.active ? 'stroke-red-800' : 'stroke-[#191f20]')
 const lineStyles = computed(() => ({
   'stroke-[#191f20]': !props.active && !props.highlight,
-  'stroke-[#e5dcc8]/40': props.highlight && !props.active,
+  'stroke-[#e3d9c0]/40': props.highlight && !props.active,
   'stroke-red-800': props.active
 }))
 </script>

--- a/components/skill/passive/SkillPassiveLine.vue
+++ b/components/skill/passive/SkillPassiveLine.vue
@@ -7,7 +7,7 @@
   />
   <path
     class="transition-all"
-    :class="lineStroke"
+    :class="lineStyles"
     :d="dpath"
     fill="none"
     stroke-width="5"
@@ -17,6 +17,7 @@
 <script setup lang="ts">
 interface Props {
   active?: boolean
+  highlight?: boolean
   el1: HTMLElement
   el2: HTMLElement
   parent: HTMLElement
@@ -27,6 +28,7 @@ interface Props {
 
 const props = withDefaults(defineProps<Props>(), {
   active: false,
+  highlight: false,
   direct: true,
   direction: '',
   path: ''
@@ -50,5 +52,10 @@ const dpath = computed(() => {
   }
 })
 
-const lineStroke = computed<string>(() => props.active ? 'stroke-red-800' : 'stroke-[#191f20]')
+// const lineStroke = computed<string>(() => props.active ? 'stroke-red-800' : 'stroke-[#191f20]')
+const lineStyles = computed(() => ({
+  'stroke-[#191f20]': !props.active && !props.highlight,
+  'stroke-[#e5dcc8]/40': props.highlight && !props.active,
+  'stroke-red-800': props.active
+}))
 </script>

--- a/components/skill/passive/test/SkillPassive.spec.ts
+++ b/components/skill/passive/test/SkillPassive.spec.ts
@@ -6,11 +6,11 @@ let wrapper: VueWrapper
 
 beforeEach(() => {
   wrapper = mount(SkillPassive as any, {
-    global: {
-      mocks: {
-        useActiveFill: () => 'fill-red-800'
-      }
-    }
+    // global: {
+    //   mocks: {
+    //     useActiveFill: () => 'fill-red-800'
+    //   }
+    // }
   })
 })
 
@@ -20,7 +20,7 @@ describe('SkillPassive.vue', () => {
 
     const outerSquareClass = outerSquareWrapper.attributes('class')
 
-    expect(outerSquareClass).toContain('!fill-[#191f20]')
+    expect(outerSquareClass).toContain('fill-[#191f20]')
   })
 
   test('outer square has the correct styles when props.active is true', async () => {

--- a/components/skill/passive/test/SkillPassive.spec.ts
+++ b/components/skill/passive/test/SkillPassive.spec.ts
@@ -33,6 +33,16 @@ describe('SkillPassive.vue', () => {
     expect(outerSquareWrapper.attributes('class')).toContain('fill-red-800')
   })
 
+  test('outer square has the correct styles when props.highlight is true', async () => {
+    await wrapper.setProps({
+      highlight: true
+    })
+
+    const outerSquareWrapper = wrapper.find('.skill-item-passive__outer-square')
+
+    expect(outerSquareWrapper.attributes('class')).toContain('fill-[#e3d9c0]')
+  })
+
   test('image is translucent by default', async () => {
     await wrapper.setProps({
       icon: 'my-icon'

--- a/components/skill/test/SkillItem.spec.ts
+++ b/components/skill/test/SkillItem.spec.ts
@@ -6,12 +6,12 @@ let wrapper: VueWrapper
 
 beforeEach(() => {
   wrapper = mount(SkillItem as any, {
-    global: {
-      // stubs: ['FontAwesomeIcon']
-      mocks: {
-        useActiveFill: () => 'fill-red-800'
-      }
-    }
+    // global: {
+    //   // stubs: ['FontAwesomeIcon']
+    //   mocks: {
+    //     useActiveFill: () => 'fill-red-800'
+    //   }
+    // }
   })
 })
 
@@ -21,7 +21,7 @@ describe('SkillItem.vue', () => {
 
     const outerSquareClass = outerSquareWrapper.attributes('class')
 
-    expect(outerSquareClass).toContain('!fill-[#191f20]')
+    expect(outerSquareClass).toContain('fill-[#191f20]')
   })
 
   test('outer square has the correct styles when props.active is true', async () => {

--- a/components/skill/test/SkillItemModifier.spec.ts
+++ b/components/skill/test/SkillItemModifier.spec.ts
@@ -6,11 +6,11 @@ let wrapper: VueWrapper
 
 beforeEach(() => {
   wrapper = mount(SkillItemModifier as any, {
-    global: {
-      mocks: {
-        useActiveFill: () => 'fill-red-800'
-      }
-    }
+    // global: {
+    //   mocks: {
+    //     useActiveFill: () => 'fill-red-800'
+    //   }
+    // }
   })
 })
 
@@ -20,7 +20,7 @@ describe('SkillItemModifier.vue', () => {
 
     const outerSquareClass = outerSquareWrapper.attributes('class')
 
-    expect(outerSquareClass).toContain('!fill-[#191f20]')
+    expect(outerSquareClass).toContain('fill-[#191f20]')
   })
 
   test('outer square has the correct styles when props.active is true', async () => {

--- a/components/skill/test/SkillLine.spec.ts
+++ b/components/skill/test/SkillLine.spec.ts
@@ -47,4 +47,12 @@ describe('SkillLine.vue', () => {
 
     expect(lineWrapper[1].attributes('class')).includes('stroke-red-800')
   })
+
+  test('renders the correct highlight stroke color', async () => {
+    const lineWrapper = wrapper.findAll('line')
+
+    await wrapper.setProps({ highlight: true })
+
+    expect(lineWrapper[1].attributes('class')).includes('stroke-[#e3d9c0]/50')
+  })
 })

--- a/components/skill/test/SkillTooltip.spec.ts
+++ b/components/skill/test/SkillTooltip.spec.ts
@@ -98,7 +98,7 @@ describe('SkillTooltip.vue', () => {
   test('displays tooltip modifiers', async () => {
     await wrapper.setProps({
       description: 'Hello {text}',
-      modifiers: [{
+      modifier: {
         active: true,
         description: 'My Modifier',
         choiceModifiers: [{
@@ -108,7 +108,7 @@ describe('SkillTooltip.vue', () => {
           active: true,
           description: 'Choice 2'
         }]
-      }]
+      }
     })
 
     const modifiersListWrapper = wrapper.find('.tooltip__modifiers-list')

--- a/components/skill/tier/SkillTier.vue
+++ b/components/skill/tier/SkillTier.vue
@@ -27,6 +27,7 @@
 
           <SkillLine
             :active="skill.modifier.active"
+            :highlight="skill.rank > 0"
             :parent="skillTier"
             :el1="skillRefs[skill.name]?.$el"
             :el2="skillModifierRefs[skill.modifier.name]?.$el"
@@ -85,6 +86,7 @@
           :icon="skill.icon"
           :rank="skill.rank"
           :rank-max="skill.rankMax"
+          :highlight="skill.rank === 0 && allowLearnSkill"
           @click="handleSkillClick(skill)"
           @contextmenu="handleSkillRightClick(skill)"
           @mouseover="handleSkillMouseOver(skill)"
@@ -96,6 +98,7 @@
             :icon="skill.icon"
             class="absolute top-[10px] left-[10px]"
             :style="{ transform: skill.modifier.transform }"
+            :highlight="skill.rank > 0"
             :active="skill.modifier.active"
             @click="handleModifierClick(skill, skill.modifier)"
             @contextmenu="handleModifierRightClick(skill.modifier)"

--- a/components/skill/tier/SkillTier.vue
+++ b/components/skill/tier/SkillTier.vue
@@ -37,6 +37,7 @@
             v-for="choiceModifier in skill.modifier.choiceModifiers"
             :key="choiceModifier.name"
             :active="choiceModifier.active"
+            :highlight="highlightChoiceModifier(choiceModifier.name, skill.modifier)"
             :parent="skillTier"
             :el1="skillModifierRefs[skill.modifier.name]?.$el"
             :el2="skillModifierRefs[choiceModifier.name]?.$el"
@@ -111,6 +112,7 @@
               :key="choiceModifier.name"
               :ref="el => { skillModifierRefs[choiceModifier.name] = el as ComponentPublicInstance }"
               :icon="skill.icon"
+              :highlight="highlightChoiceModifier(choiceModifier.name, skill.modifier)"
               class="choice-modifier absolute top-0 left-0"
               :style="{ transform: choiceModifier.transform }"
               :active="choiceModifier.active"
@@ -262,5 +264,14 @@ function handlePassiveMouseOver (passive: any): void {
   const el = skillRefs.value[passive.name]?.$el
 
   tooltipStore.setPassive(passive, el)
+}
+
+function highlightChoiceModifier (choiceModifierName: string, modifier: any) {
+  const otherModifierActive = !!modifier.choiceModifiers.find(
+    (choiceModifier: any) => {
+      return choiceModifier.name !== choiceModifierName && choiceModifier.active
+    }
+  )
+  return modifier.active && !otherModifierActive
 }
 </script>

--- a/components/skill/tier/SkillTier.vue
+++ b/components/skill/tier/SkillTier.vue
@@ -19,6 +19,7 @@
           <SkillLine
             v-if="skillRefs[skill.name]"
             :active="skill.rank > 0"
+            :highlight="skill.rank === 0 && allowLearnSkill"
             :parent="skillTier"
             :el1="skillTierNode?.$el"
             :el2="skillRefs[skill.name]?.$el"

--- a/components/skill/tier/SkillTier.vue
+++ b/components/skill/tier/SkillTier.vue
@@ -58,6 +58,7 @@
               :key="`${passive.name}${index}`"
               :parent="skillTier"
               :active="line.active"
+              :highlight="highlightPassive(passive, passiveGroup)"
               :el1="line.el"
               :el2="skillRefs[passive.name]?.$el"
               :direct="passive.direct"
@@ -138,6 +139,7 @@
             :icon="passive.icon"
             :rank="passive.rank"
             :rank-max="passive.rankMax"
+            :highlight="highlightPassive(passive, passiveGroup)"
             @click="handlePassiveClick(passive, passiveGroup)"
             @contextmenu="handlePassiveRightClick(passive, passiveGroup)"
             @mouseover="handlePassiveMouseOver(passive)"
@@ -151,7 +153,7 @@
 </template>
 
 <script setup lang="ts">
-import { ISkillTier } from '@/utils/skills'
+import { ISkillTier, ISkillPassive } from '@/utils/skills'
 import { useTooltipStore } from '@/store/tooltip'
 import SkillItem from '@/components/skill/SkillItem.vue'
 import SkillItemModifier from '@/components/skill/SkillItemModifier.vue'
@@ -273,5 +275,16 @@ function highlightChoiceModifier (choiceModifierName: string, modifier: any) {
     }
   )
   return modifier.active && !otherModifierActive
+}
+
+function highlightPassive (passive: any, passiveGroup: any) {
+  if (passive.connected && allowLearnSkill.value) return true
+
+  const requiredPassivesRank = passiveGroup.items.filter((passiveItem: ISkillPassive) => {
+    return passiveItem.requiredFor?.find(requirement => requirement.name === passive.name)
+  }).reduce((acc: number, curr: any) => acc + curr.rank, 0)
+
+  // const meetsRequirements = passiveGroup.
+  return requiredPassivesRank > 0
 }
 </script>

--- a/components/skill/tier/test/SkillTier.spec.ts
+++ b/components/skill/tier/test/SkillTier.spec.ts
@@ -24,9 +24,9 @@ const createWrapper = (props = {}) => {
 
 const testSkill = {
   name: 'Spark',
-  description: 'Launch a bolt of lightning that shocks an enemy <span class="text-orange-300">4</span> times, dealing <span class="text-orange-300">[{damage}]</span> damage each hit.',
+  description: '',
   descriptionValues: {
-    damage: '8%,8.8%,9.6%,10.4%,11.2%'
+    damage: ''
   },
   type: 'Basic',
   school: 'Shock',
@@ -37,17 +37,17 @@ const testSkill = {
   rankMax: 5,
   modifier: {
     name: 'Enhanced Spark',
-    description: 'Each time <span class="text-white">Spark</span> hits its primary target, it has a <span class="text-orange-300">20%</span> chance to hit up to 3 additional enemies, dealing <span class="text-orange-300">6%</span> damage. If there are no other enemies to hit, Spark instead deals <span class="text-orange-300">x20%</span> increased damage to its primary target.',
+    description: '',
     transform: '',
     active: false,
     choiceModifiers: [{
       name: 'Glinting Spark',
-      description: '<span class="text-white">Spark</span> grants <span class="text-orange-300">+2%</span> increased Critical Strike Chance per cast for <span class="text-orange-300">3</span> seconds, up to <span class="text-orange-300">+10%.</span>',
+      description: '',
       transform: '',
       active: false
     }, {
       name: 'Flickering Spark',
-      description: 'Each time <span class="text-white">Spark</span> hits an enemy it has a <span class="text-orange-300">3%</span> chance to form a <span class="underline">Crackling Energy</span>.',
+      description: '',
       transform: '',
       active: false
     }]
@@ -57,6 +57,28 @@ const testSkill = {
 const testLearnedSkill = {
   ...testSkill,
   rank: 2
+}
+
+const testLearnedSkillWithSelectedChoiceModifiers = {
+  ...testSkill,
+  rank: 2,
+  modifier: {
+    name: 'Enhanced Spark',
+    description: '',
+    transform: '',
+    active: true,
+    choiceModifiers: [{
+      name: 'Glinting Spark',
+      description: '',
+      transform: '',
+      active: true
+    }, {
+      name: 'Flickering Spark',
+      description: '',
+      transform: '',
+      active: false
+    }]
+  }
 }
 
 const testTier = {
@@ -69,7 +91,8 @@ const testTier = {
       name: 'Passive',
       desription: 'test',
       transform: '',
-      rank: 0
+      rank: 0,
+      connected: true
     }]
   }]
 }
@@ -95,6 +118,13 @@ const testTierRankDown = {
   passives: []
 }
 
+const testTierWithChoiceMods = {
+  name: 'basic',
+  skills: [testLearnedSkillWithSelectedChoiceModifiers],
+  rankRequired: 0,
+  passives: []
+}
+
 async function setTestTier (tier = testTier) {
   await wrapper.setProps({
     tier
@@ -114,7 +144,7 @@ describe('SkillTier.vue', () => {
   })
 
   test('clicking a SkillItem emits the increment-skill event', async () => {
-    await setTestTier()
+    await setTestTier(testTierWithChoiceMods)
 
     const skillItemWrapper = wrapper.findComponent({ name: 'SkillItem' })
     await skillItemWrapper.vm.$emit('click', {})

--- a/components/skill/tree/SkillTree.vue
+++ b/components/skill/tree/SkillTree.vue
@@ -15,7 +15,7 @@
       :type="tooltipStore.type"
       :school="tooltipStore.school"
       :damage-type="tooltipStore.damageType"
-      :modifiers="tooltipStore.modifiers"
+      :modifier="tooltipStore.modifier"
       :category="tooltipStore.category"
       :translate-x="tooltipStore.x"
       :translate-y="tooltipStore.y"

--- a/composables/theme.ts
+++ b/composables/theme.ts
@@ -1,1 +1,0 @@
-export const useActiveFill = (): string => 'fill-red-800'

--- a/store/tooltip.ts
+++ b/store/tooltip.ts
@@ -18,7 +18,7 @@ export const useTooltipStore = defineStore('tooltip', {
     type: '' as string,
     school: '' as string,
     damageType: '' as string | undefined,
-    modifiers: [] as ISkillModifier[],
+    modifier: {} as ISkillModifier | undefined,
     x: 0 as number,
     y: 0 as number
   }),
@@ -37,7 +37,7 @@ export const useTooltipStore = defineStore('tooltip', {
       this.damageType = skill.damageType
       this.description = skill.description
       this.descriptionValues = skill.descriptionValues
-      this.modifiers = skill.modifiers || []
+      this.modifier = skill.modifier
       this.icon = skill.icon
       this.category = 'skill'
       this.x = refBox.left + offset
@@ -58,7 +58,7 @@ export const useTooltipStore = defineStore('tooltip', {
       this.damageType = ''
       this.description = skill.description
       this.descriptionValues = skill.descriptionValues
-      this.modifiers = []
+      this.modifier = undefined
       this.icon = skill.icon
       this.category = 'passive'
       this.x = refBox.left + offset
@@ -79,7 +79,7 @@ export const useTooltipStore = defineStore('tooltip', {
       this.active = modifier.active
       this.description = modifier.description
       this.descriptionValues = {}
-      this.modifiers = []
+      this.modifier = undefined
       this.icon = icon
       this.category = choiceModifier ? 'choice-modifier' : 'modifier'
       this.x = refBox.left + offset


### PR DESCRIPTION
Added a highlight effect for any available skills, modifiers, passives, and lines.

![image](https://user-images.githubusercontent.com/6521913/233678243-36ab2077-c1de-4f20-a75c-729a232e1115.png)

closes #28 